### PR TITLE
Handle `maxdigits` axis attribute

### DIFF
--- a/atlasplots/root_helpers.py
+++ b/atlasplots/root_helpers.py
@@ -803,6 +803,9 @@ def set_axis_attributes(obj, **kwargs):
     if "labelsize" in kwargs:
         obj.SetLabelSize(kwargs["labelsize"])
 
+    if "maxdigits" in kwargs:
+        obj.SetMaxDigits(kwargs["maxdigits"])
+
     if "ticklength" in kwargs:
         obj.SetTickLength(kwargs["ticklength"])
 


### PR DESCRIPTION
I was playing around with this awesome package and realized that it couldn't handle the `maxdigits` axis attribute, so here's a quick PR to add support for it if you'd like @joeycarter :slightly_smiling_face: 