### PR TITLE
Fix offset of XAxis title in ratioplots

### DIFF
--- a/atlasplots/api.py
+++ b/atlasplots/api.py
@@ -162,7 +162,7 @@ def ratio_plot(hspace=0, **fig_kw):
 
     ax1.frame.GetYaxis().SetTitleOffset(1.9)
     ax2.frame.GetYaxis().SetTitleOffset(1.9)
-    ax2.frame.GetXaxis().SetTitleOffset(1.4 / 0.37)
+    ax2.frame.GetXaxis().SetTitleOffset(0)
     ax2.frame.GetYaxis().SetNdivisions(505)
 
     return fig, (ax1, ax2)


### PR DESCRIPTION
When I ran a ratioplot, the xaxis title was not there however I tried.
Setting the value to zero manually fixed this for me